### PR TITLE
fix(utils/parse): escape quotes in image URL

### DIFF
--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -140,7 +140,7 @@ export default class Parse {
 		}
 
 		return {
-			url: url.trim(),
+			url: `"${url.trim().replace(/(["\\])/g, "\\$1")}"`,
 			external,
 			type,
 			...options,


### PR DESCRIPTION
If the image name or one of its parent folder contains a single or double quote, the URL would cause a syntax error in the resulting CSS. This commit fixes this by wrapping the URL in double quotes and escaping any inner double quotes and backslashes in the process.